### PR TITLE
update ppx_deriving_yojson bound

### DIFF
--- a/opam
+++ b/opam
@@ -22,7 +22,7 @@ install: [
 remove: [["ocamlfind" "remove" "socket-daemon"]]
 depends: [
   "lwt" { >= "2.5" }
-  "ppx_deriving_yojson" { >= "2.4" }
+  "ppx_deriving_yojson" { >= "2.4" & < "3.0" }
 ]
 
 available: [ ocaml-version >= "4.02.2"]


### PR DESCRIPTION
The build may currently fail as socket-daemon is incompatible with recent versions of ppx_deriving_yojson.

opam-builder report:
  <http://opam.ocamlpro.com/builder/html/socket-daemon/socket-daemon.0.2.0/e124ff93985549453e5c73bbdda79508>

```

# File "sdaemon_common.ml", line 26, characters 6-11:
# Error: This pattern matches values of type [? `Ok of 'a ]
#        but a pattern was expected which matches values of type
#          client_msg Ppx_deriving_yojson_runtime.error_or =
#            (client_msg, string) Result.result
```

According to its [Changelog.md](https://github.com/whitequark/ppx_deriving_yojson/blob/master/CHANGELOG.md), ppx_deriving_yojson uses the 4.03 `result` type since version 3.0. (`ppx_deriving` itself switched at version 4.0.)

Note that updating the code to, in a new release, be compatible with the more recent ppx_deriving_yojson release would probably help ensure compatibility with future OCaml releases -- as I would guess that only the most recent of ppx_deriving / ppx_deriving_yojson will be maintained to support newer OCaml releases, although I guess only @whitequark knows.